### PR TITLE
Add missing right bracket to Serial.println() page

### DIFF
--- a/Language/Functions/Communication/Serial/println.adoc
+++ b/Language/Functions/Communication/Serial/println.adoc
@@ -14,7 +14,7 @@ title: Serial.println()
 
 [float]
 === Description
-Prints data to the serial port as human-readable ASCII text followed by a carriage return character (ASCII 13, or '\r') and a newline character (ASCII 10, or '\n'). This command takes the same forms as link:../print[Serial.print().
+Prints data to the serial port as human-readable ASCII text followed by a carriage return character (ASCII 13, or '\r') and a newline character (ASCII 10, or '\n'). This command takes the same forms as link:../print[Serial.print()].
 [%hardbreaks]
 
 


### PR DESCRIPTION
Closes https://github.com/arduino/reference-jp/issues/72