### PR TITLE
Fixed Link Error

### DIFF
--- a/Language/Functions/Communication/serial.adoc
+++ b/Language/Functions/Communication/serial.adoc
@@ -70,7 +70,7 @@ link:../serial/serialEvent[serialEvent()]
 === See also
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/ReadAsciiString[ReadAsciiString^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/ReadASCIIString[ReadASCIIString^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/ASCIITable[ASCII TAble^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Dimmer[Dimmer^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Graph[Graph^]


### PR DESCRIPTION
Example for ReadASCIIString was referring to ReadAsciiString giving a
404-error.

Closes https://github.com/arduino/reference-jp/issues/77