### PR TITLE
Fix typo in reference operator page

### DIFF
--- a/Language/Structure/Pointer Access Operators/reference.adoc
+++ b/Language/Structure/Pointer Access Operators/reference.adoc
@@ -1,6 +1,6 @@
 ---
 title: "&"
-title_expanded: reference opearator
+title_expanded: reference operator
 categories: [ "Structure" ]
 subCategories: [ "Pointer Access Operators" ]
 ---


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-jp/issues/90